### PR TITLE
Feat/form information help page

### DIFF
--- a/en/FormInformation/FormInformationContent.html
+++ b/en/FormInformation/FormInformationContent.html
@@ -6,7 +6,7 @@
   <h3>Label</h3>
   <p>The Label field allows you to provide a user-friendly, language-specific label for each attribute. This is what users will see in forms and questionnaires instead of the technical attribute name. Labels should be clear, descriptive, and appropriate for the target audience.</p>
   <p>Labels are where your questionnaire question text will go. This can include full sentences that provide clear instructions to users. For example, a label might read: "On a scale of 1 to 5, how would you rate your experience?" or "Please describe your main concerns about this product."</p>
-  <p>Labels have a maximum length of 100 characters and can be customized for each language in your schema.</p>
+  <p>Labels can be customized for each language in your schema.</p>
   
   <h3>Placeholder</h3>
   <p>The Placeholder field provides example text or instructions that appear inside form input fields to guide users on what type of information to enter. Placeholders are particularly useful for Text and Array[Text] attribute types where users need to enter free-form text.</p>

--- a/en/FormInformation/FormInformationContent.html
+++ b/en/FormInformation/FormInformationContent.html
@@ -5,7 +5,8 @@
   
   <h3>Label</h3>
   <p>The Label field allows you to provide a user-friendly, language-specific label for each attribute. This is what users will see in forms and questionnaires instead of the technical attribute name. Labels should be clear, descriptive, and appropriate for the target audience.</p>
-  <p>Labels can be customized for each language in your schema.</p>
+  <p>Labels are where your questionnaire question text will go. This can include full sentences that provide clear instructions to users. For example, a label might read: "On a scale of 1 to 5, how would you rate your experience?" or "Please describe your main concerns about this product."</p>
+  <p>Labels have a maximum length of 100 characters and can be customized for each language in your schema.</p>
   
   <h3>Placeholder</h3>
   <p>The Placeholder field provides example text or instructions that appear inside form input fields to guide users on what type of information to enter. Placeholders are particularly useful for Text and Array[Text] attribute types where users need to enter free-form text.</p>

--- a/en/FormInformation/FormInformationContent.html
+++ b/en/FormInformation/FormInformationContent.html
@@ -5,12 +5,12 @@
   
   <h3>Label</h3>
   <p>The Label field allows you to provide a user-friendly, language-specific label for each attribute. This is what users will see in forms and questionnaires instead of the technical attribute name. Labels should be clear, descriptive, and appropriate for the target audience.</p>
-  <p>Labels have a maximum length of 100 characters and can be customized for each language in your schema.</p>
+  <p>Labels can be customized for each language in your schema.</p>
   
   <h3>Placeholder</h3>
   <p>The Placeholder field provides example text or instructions that appear inside form input fields to guide users on what type of information to enter. Placeholders are particularly useful for Text and Array[Text] attribute types where users need to enter free-form text.</p>
   <p>Placeholders are only available for Text and Array[Text] attribute types, as these are the only types that accept free text input from users. For other attribute types (like Numeric, Boolean, etc.), the placeholder field is not editable.</p>
-  <p>Placeholders have a maximum length of 100 characters and should provide clear, helpful guidance to users about the expected format or content for the field.</p>
+  <p>Placeholders should provide clear, helpful guidance to users about the expected format or content for the field.</p>
   
   <h3>Format Rules Integration</h3>
   <p>The Form Information overlay displays the format rules that have been defined for each attribute. These format rules help ensure data consistency and provide validation for user input. The format rules are read-only in this interface and must be configured in the Format Rules overlay.</p>
@@ -19,5 +19,5 @@
   <p>Form Information supports multiple languages, allowing you to create language-specific labels and placeholders for your attributes. This is particularly useful for international schemas or when working with multilingual datasets.</p>
   
   <h3>Prerequisites</h3>
-  <p>Before using the Form Information overlay, you must first add Format Rules for your attributes. The Form Information overlay requires format rules to be defined, as it displays and works in conjunction with these validation rules.</p>
+  <p>Before using the Form Information overlay, you must first add Format Rules for your attributes. The Form Information overlay requires format rules to be defined.</p>
 </div>

--- a/en/FormInformation/FormInformationContent.html
+++ b/en/FormInformation/FormInformationContent.html
@@ -1,0 +1,23 @@
+<div>
+  <h1 style="text-align: center; color: #94002a; font-size: 3.25rem;">Form Information</h1>
+  <br>
+  <p>The Form Information overlay allows you to specify how each attribute and its corresponding answer field appear in a questionnaire or form interface.</p>
+  
+  <h3>Label</h3>
+  <p>The Label field allows you to provide a user-friendly, language-specific label for each attribute. This is what users will see in forms and questionnaires instead of the technical attribute name. Labels should be clear, descriptive, and appropriate for the target audience.</p>
+  <p>Labels have a maximum length of 100 characters and can be customized for each language in your schema.</p>
+  
+  <h3>Placeholder</h3>
+  <p>The Placeholder field provides example text or instructions that appear inside form input fields to guide users on what type of information to enter. Placeholders are particularly useful for Text and Array[Text] attribute types where users need to enter free-form text.</p>
+  <p>Placeholders are only available for Text and Array[Text] attribute types, as these are the only types that accept free text input from users. For other attribute types (like Numeric, Boolean, etc.), the placeholder field is not editable.</p>
+  <p>Placeholders have a maximum length of 100 characters and should provide clear, helpful guidance to users about the expected format or content for the field.</p>
+  
+  <h3>Format Rules Integration</h3>
+  <p>The Form Information overlay displays the format rules that have been defined for each attribute. These format rules help ensure data consistency and provide validation for user input. The format rules are read-only in this interface and must be configured in the Format Rules overlay.</p>
+  
+  <h3>Multi-language Support</h3>
+  <p>Form Information supports multiple languages, allowing you to create language-specific labels and placeholders for your attributes. This is particularly useful for international schemas or when working with multilingual datasets.</p>
+  
+  <h3>Prerequisites</h3>
+  <p>Before using the Form Information overlay, you must first add Format Rules for your attributes. The Form Information overlay requires format rules to be defined, as it displays and works in conjunction with these validation rules.</p>
+</div>

--- a/en/FormInformation/index.html
+++ b/en/FormInformation/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Form Information Help</title>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+    }
+    header {
+      background-color: #94002a;
+      color: white;
+      padding: 0px 20px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    
+    .logo img {
+      height: auto;
+      width: 250px;
+    }
+
+    .left {
+      font-size:40px;
+    }
+
+    #contentContainer {
+      padding: 0px 20px;
+    }
+
+    h3 {
+      font-size: 2rem;
+      margin-block-start: 0;
+      margin-block-end: 0;
+    }
+
+    p {
+      font-size: 20px;
+      line-height: 30px;
+    }
+  </style>
+  <script>
+    $(document).ready(function() {
+      $("#headerContainer").load("../../header.html");
+      $("#contentContainer").load("FormInformationContent.html");
+      $("#footerContainer").load("../../footer.html");
+    });
+  </script>
+</head>
+<body>
+
+    <!-- Header -->
+    <div id="headerContainer"></div>
+
+    <!-- Content -->
+    <main id="contentContainer"></main>
+
+    <br>
+    <hr>
+
+    <!-- Footer -->
+    <div id="footerContainer"></div>
+
+</body>
+</html>

--- a/en/Overlays/OverlaysContent.html
+++ b/en/Overlays/OverlaysContent.html
@@ -13,6 +13,7 @@
     <li><strong>Format Rules: </strong> Specify the formatting rule that applies to data for each attribute.</li>
     <li><strong>Cardinality: </strong> Specify the exact, minimum or maximum (or both minimum and maximum) number of entries allowed in a data record for each attribute.</li>
 	<li><strong>Unit Framing: </strong> Units which have been already defined can be mapped (framed) to the UCUM unit ontology. This helps users be unambiguous when describing their units.</li>
+	<li><strong>Form Information: </strong> Specify how each attribute and its corresponding answer field appear in a questionnaire.</li>
   </ul>
   <br>
 </div>

--- a/fr/FormInformation/FormInformationContent.html
+++ b/fr/FormInformation/FormInformationContent.html
@@ -5,6 +5,7 @@
   
   <h3>Étiquette</h3>
   <p>Le champ Étiquette vous permet de fournir une étiquette conviviale et spécifique à la langue pour chaque attribut. C'est ce que les utilisateurs verront dans les formulaires et questionnaires au lieu du nom technique de l'attribut. Les étiquettes doivent être claires, descriptives et appropriées pour le public cible.</p>
+  <p>Les étiquettes sont l'endroit où votre texte de question de questionnaire apparaîtra. Cela peut inclure des phrases complètes qui fournissent des instructions claires aux utilisateurs. Par exemple, une étiquette pourrait lire : "Sur une échelle de 1 à 5, comment évaluez-vous votre expérience ?" ou "Veuillez décrire vos principales préoccupations concernant ce produit."</p>
   <p>Les étiquettes ont une longueur maximale de 100 caractères et peuvent être personnalisées pour chaque langue dans votre schéma.</p>
   
   <h3>Espace réservé</h3>

--- a/fr/FormInformation/FormInformationContent.html
+++ b/fr/FormInformation/FormInformationContent.html
@@ -6,12 +6,12 @@
   <h3>Étiquette</h3>
   <p>Le champ Étiquette vous permet de fournir une étiquette conviviale et spécifique à la langue pour chaque attribut. C'est ce que les utilisateurs verront dans les formulaires et questionnaires au lieu du nom technique de l'attribut. Les étiquettes doivent être claires, descriptives et appropriées pour le public cible.</p>
   <p>Les étiquettes sont l'endroit où votre texte de question de questionnaire apparaîtra. Cela peut inclure des phrases complètes qui fournissent des instructions claires aux utilisateurs. Par exemple, une étiquette pourrait lire : "Sur une échelle de 1 à 5, comment évaluez-vous votre expérience ?" ou "Veuillez décrire vos principales préoccupations concernant ce produit."</p>
-  <p>Les étiquettes ont une longueur maximale de 100 caractères et peuvent être personnalisées pour chaque langue dans votre schéma.</p>
+  <p>Les étiquettes peuvent être personnalisées pour chaque langue dans votre schéma.</p>
   
   <h3>Espace réservé</h3>
   <p>Le champ Espace réservé fournit un exemple de texte ou des instructions qui apparaissent à l'intérieur des champs de saisie de formulaire pour guider les utilisateurs sur le type d'informations à saisir. Les espaces réservés sont particulièrement utiles pour les types d'attributs Texte et Tableau[Texte] où les utilisateurs doivent saisir du texte libre.</p>
   <p>Les espaces réservés ne sont disponibles que pour les types d'attributs Texte et Tableau[Texte], car ce sont les seuls types qui acceptent la saisie de texte libre des utilisateurs. Pour les autres types d'attributs (comme Numérique, Booléen, etc.), le champ d'espace réservé n'est pas modifiable.</p>
-  <p>Les espaces réservés ont une longueur maximale de 100 caractères et doivent fournir des conseils clairs et utiles aux utilisateurs sur le format ou le contenu attendu pour le champ.</p>
+  <p>Les espaces réservés doivent fournir des conseils clairs et utiles aux utilisateurs sur le format ou le contenu attendu pour le champ.</p>
   
   <h3>Intégration des règles de format</h3>
   <p>La superposition d'informations de formulaire affiche les règles de format qui ont été définies pour chaque attribut. Ces règles de format aident à assurer la cohérence des données et fournissent une validation pour la saisie des utilisateurs. Les règles de format sont en lecture seule dans cette interface et doivent être configurées dans la superposition des règles de format.</p>

--- a/fr/FormInformation/FormInformationContent.html
+++ b/fr/FormInformation/FormInformationContent.html
@@ -1,0 +1,23 @@
+<div>
+  <h1 style="text-align: center; color: #94002a; font-size: 3.25rem;">Informations de formulaire</h1>
+  <br>
+  <p>La superposition d'informations de formulaire vous permet de spécifier comment chaque attribut et son champ de réponse correspondant apparaissent dans un questionnaire ou une interface de formulaire.</p>
+  
+  <h3>Étiquette</h3>
+  <p>Le champ Étiquette vous permet de fournir une étiquette conviviale et spécifique à la langue pour chaque attribut. C'est ce que les utilisateurs verront dans les formulaires et questionnaires au lieu du nom technique de l'attribut. Les étiquettes doivent être claires, descriptives et appropriées pour le public cible.</p>
+  <p>Les étiquettes ont une longueur maximale de 100 caractères et peuvent être personnalisées pour chaque langue dans votre schéma.</p>
+  
+  <h3>Espace réservé</h3>
+  <p>Le champ Espace réservé fournit un exemple de texte ou des instructions qui apparaissent à l'intérieur des champs de saisie de formulaire pour guider les utilisateurs sur le type d'informations à saisir. Les espaces réservés sont particulièrement utiles pour les types d'attributs Texte et Tableau[Texte] où les utilisateurs doivent saisir du texte libre.</p>
+  <p>Les espaces réservés ne sont disponibles que pour les types d'attributs Texte et Tableau[Texte], car ce sont les seuls types qui acceptent la saisie de texte libre des utilisateurs. Pour les autres types d'attributs (comme Numérique, Booléen, etc.), le champ d'espace réservé n'est pas modifiable.</p>
+  <p>Les espaces réservés ont une longueur maximale de 100 caractères et doivent fournir des conseils clairs et utiles aux utilisateurs sur le format ou le contenu attendu pour le champ.</p>
+  
+  <h3>Intégration des règles de format</h3>
+  <p>La superposition d'informations de formulaire affiche les règles de format qui ont été définies pour chaque attribut. Ces règles de format aident à assurer la cohérence des données et fournissent une validation pour la saisie des utilisateurs. Les règles de format sont en lecture seule dans cette interface et doivent être configurées dans la superposition des règles de format.</p>
+  
+  <h3>Support multilingue</h3>
+  <p>Les informations de formulaire prennent en charge plusieurs langues, vous permettant de créer des étiquettes et des espaces réservés spécifiques à la langue pour vos attributs. Ceci est particulièrement utile pour les schémas internationaux ou lorsque vous travaillez avec des ensembles de données multilingues.</p>
+  
+  <h3>Prérequis</h3>
+  <p>Avant d'utiliser la superposition d'informations de formulaire, vous devez d'abord ajouter des règles de format pour vos attributs. La superposition d'informations de formulaire nécessite que des règles de format soient définies, car elle affiche et fonctionne en conjonction avec ces règles de validation.</p>
+</div>

--- a/fr/FormInformation/FormInformationContent.html
+++ b/fr/FormInformation/FormInformationContent.html
@@ -19,5 +19,5 @@
   <p>Les informations de formulaire prennent en charge plusieurs langues, vous permettant de créer des étiquettes et des espaces réservés spécifiques à la langue pour vos attributs. Ceci est particulièrement utile pour les schémas internationaux ou lorsque vous travaillez avec des ensembles de données multilingues.</p>
   
   <h3>Prérequis</h3>
-  <p>Avant d'utiliser la superposition d'informations de formulaire, vous devez d'abord ajouter des règles de format pour vos attributs. La superposition d'informations de formulaire nécessite que des règles de format soient définies, car elle affiche et fonctionne en conjonction avec ces règles de validation.</p>
+  <p>Avant d'utiliser la superposition d'informations de formulaire, vous devez d'abord ajouter des règles de format pour vos attributs. La superposition d'informations de formulaire nécessite que des règles de format soient définies.</p>
 </div>

--- a/fr/FormInformation/index.html
+++ b/fr/FormInformation/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Aide sur les informations de formulaire</title>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+    }
+    header {
+      background-color: #94002a;
+      color: white;
+      padding: 0px 20px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    
+    .logo img {
+      height: auto;
+      width: 250px;
+    }
+
+    .left {
+      font-size:40px;
+    }
+
+    #contentContainer {
+      padding: 0px 20px;
+    }
+
+    h3 {
+      font-size: 2rem;
+      margin-block-start: 0;
+      margin-block-end: 0;
+    }
+
+    p {
+      font-size: 20px;
+      line-height: 30px;
+    }
+  </style>
+  <script>
+    $(document).ready(function() {
+      $("#headerContainer").load("../../header.html");
+      $("#contentContainer").load("FormInformationContent.html");
+      $("#footerContainer").load("../../footer.html");
+    });
+  </script>
+</head>
+<body>
+
+    <!-- Header -->
+    <div id="headerContainer"></div>
+
+    <!-- Content -->
+    <main id="contentContainer"></main>
+
+    <br>
+    <hr>
+
+    <!-- Footer -->
+    <div id="footerContainer"></div>
+
+</body>
+</html>

--- a/fr/Overlays/OverlaysContent.html
+++ b/fr/Overlays/OverlaysContent.html
@@ -13,6 +13,7 @@ La liste suivante inclut les superpositions supplémentaires qui peuvent être a
 <li><strong>Règles de formatage :</strong> Spécifiez la règle de formatage qui s'applique aux données pour chaque attribut.</li>
 <li><strong>Cardinalité :</strong> Spécifiez le nombre exact, minimal ou maximal (ou minimal et maximal) d'entrées autorisées dans un enregistrement de données pour chaque attribut.</li>
 <li><strong>Encadrement des unités :</strong> Les unités déjà définies peuvent être mappées (encadrées) à l'ontologie d'unité UCUM. Cela permet aux utilisateurs de décrire leurs unités sans ambiguïté.</li>
+<li><strong>Informations de formulaire :</strong> Spécifiez comment chaque attribut et son champ de réponse correspondant apparaissent dans un questionnaire.</li>
 </ul>
 <br>
 </div>


### PR DESCRIPTION
feat: Add Form Information help page

- Create bilingual Form Information help page (EN/FR)
- Add comprehensive documentation for Labels, Placeholders, and Format Rules integration
- Update Header component to link to new help page
- Follows existing help page structure and styling